### PR TITLE
Add LLM-powered testing agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,33 @@
 vitoi/vitoi is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## Test Agent
+
+This repository includes a simple testing agent powered by OpenAI. The agent can:
+
+1. Analyze a natural language requirement.
+2. Generate a pytest script with help from the language model.
+3. Execute the script and collect JSON results.
+4. Summarize the report and optionally send it via email.
+
+### Usage
+
+Install dependencies first (requires `openai`, `pytest` and `pytest-json-report`):
+
+```bash
+pip install openai pytest pytest-json-report
+```
+
+Then run the agent:
+
+```bash
+python run_agent.py "your requirement text" --api-key YOUR_OPENAI_KEY
+```
+
+Provide SMTP parameters to email the report:
+
+```bash
+python run_agent.py "..." --api-key KEY --smtp-host smtp.example.com \
+    --smtp-to user@example.com --smtp-user youruser --smtp-password yourpass
+```

--- a/run_agent.py
+++ b/run_agent.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Command line interface for the test agent."""
+from test_agent.agent import TestAgent, SMTPSettings
+import argparse
+
+parser = argparse.ArgumentParser(description="Run the LLM-based test agent")
+parser.add_argument("requirement", help="Requirement description text")
+parser.add_argument("--api-key", dest="api_key", required=True, help="OpenAI API key")
+parser.add_argument("--smtp-host", dest="smtp_host")
+parser.add_argument("--smtp-to", dest="smtp_to")
+parser.add_argument("--smtp-user", dest="smtp_user")
+parser.add_argument("--smtp-password", dest="smtp_password")
+args = parser.parse_args()
+
+smtp = None
+if args.smtp_host and args.smtp_to:
+    smtp = SMTPSettings(
+        host=args.smtp_host,
+        to_addr=args.smtp_to,
+        user=args.smtp_user,
+        password=args.smtp_password,
+    )
+
+agent = TestAgent(api_key=args.api_key, smtp=smtp)
+plan = agent.analyze_requirements(args.requirement)
+script = agent.generate_test_script(plan)
+report = agent.run_tests(script)
+summary = agent.summarize(report)
+agent.send_report(summary)

--- a/test_agent/agent.py
+++ b/test_agent/agent.py
@@ -1,0 +1,86 @@
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from email.mime.text import MIMEText
+from typing import Optional
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai may not be installed
+    openai = None
+
+
+def _call_openai(prompt: str, api_key: str) -> str:
+    if openai is None:
+        raise RuntimeError("openai package is required to call the API")
+    openai.api_key = api_key
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp["choices"][0]["message"]["content"].strip()
+
+
+@dataclass
+class SMTPSettings:
+    host: str
+    port: int = 25
+    user: Optional[str] = None
+    password: Optional[str] = None
+    from_addr: Optional[str] = None
+    to_addr: Optional[str] = None
+
+
+class TestAgent:
+    """Simple testing agent using OpenAI to generate and run tests."""
+
+    def __init__(self, api_key: str, smtp: Optional[SMTPSettings] = None):
+        self.api_key = api_key
+        self.smtp = smtp
+
+    def analyze_requirements(self, text: str) -> str:
+        prompt = (
+            "你是一名软件测试专家。请根据以下需求列出关键测试点并给出测试计划:\n" + text
+        )
+        return _call_openai(prompt, self.api_key)
+
+    def generate_test_script(
+        self, plan: str, script_path: str = "test_generated.py"
+    ) -> str:
+        prompt = "根据以下测试计划，为 pytest 生成完整的测试脚本:\n" + plan
+        code = _call_openai(prompt, self.api_key)
+        with open(script_path, "w", encoding="utf-8") as fh:
+            fh.write(code)
+        return script_path
+
+    def run_tests(self, script_path: str) -> dict:
+        subprocess.run(["pytest", script_path, "-q", "--json-report"], check=False)
+        report_path = ".report.json"
+        if os.path.exists(report_path):
+            with open(report_path, encoding="utf-8") as fh:
+                return json.load(fh)
+        return {}
+
+    def summarize(self, report: dict) -> str:
+        prompt = (
+            "以下是 pytest 生成的 JSON 报告，请给出测试总结并指出失败原因:\n"
+            + json.dumps(report)
+        )
+        return _call_openai(prompt, self.api_key)
+
+    def send_report(self, summary: str) -> None:
+        if not self.smtp or not self.smtp.to_addr:
+            print(summary)
+            return
+        import smtplib
+
+        msg = MIMEText(summary, "plain", "utf-8")
+        msg["Subject"] = "自动化测试报告"
+        from_addr = self.smtp.from_addr or self.smtp.user
+        msg["From"] = from_addr
+        msg["To"] = self.smtp.to_addr
+        with smtplib.SMTP(self.smtp.host, self.smtp.port) as server:
+            if self.smtp.user and self.smtp.password:
+                server.login(self.smtp.user, self.smtp.password)
+            server.sendmail(from_addr, [self.smtp.to_addr], msg.as_string())

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,2 @@
+def test_true():
+    assert True


### PR DESCRIPTION
## Summary
- implement a simple testing agent that uses OpenAI to analyze requirements, generate tests, run them and send a report
- add CLI entry script `run_agent.py`
- document usage in `README.md`
- include a trivial pytest example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400fb1b9d4832382135582f9dcc149