### PR TITLE
Add static meeting_ui.html mockup for message/chat UI

### DIFF
--- a/meeting_ui.html
+++ b/meeting_ui.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>消息页 - Builder</title>
+  </head>
+  <body style="margin:0;background:#f0f2f5;font-family:PingFang SC,Microsoft YaHei,sans-serif;">
+    <div id="frame" data-builder-node="Frame" data-builder-name="消息页面" style="width:2048px;height:1435px;background:#cfd8e8;padding:16px;box-sizing:border-box;">
+      <div id="app" data-builder-node="App" data-builder-name="主容器" style="width:100%;height:100%;display:flex;gap:12px;">
+
+        <div id="nav" data-builder-node="Sidebar" data-builder-name="左侧导航" style="width:140px;height:100%;background:#c5cee0;border-radius:20px;display:flex;flex-direction:column;align-items:center;padding-top:20px;">
+          <div style="display:flex;gap:10px;margin-bottom:22px;">
+            <div style="width:18px;height:18px;border-radius:9px;background:#ea6658;"></div>
+            <div style="width:18px;height:18px;border-radius:9px;background:#efba3e;"></div>
+            <div style="width:18px;height:18px;border-radius:9px;background:#5db957;"></div>
+          </div>
+          <div style="width:62px;height:62px;border-radius:31px;background:#8c7be9;color:#fff;display:flex;align-items:center;justify-content:center;font-size:38px;">化翠</div>
+          <div style="margin-top:36px;display:flex;flex-direction:column;gap:18px;width:100%;align-items:center;">
+            <div style="width:64px;height:64px;border-radius:18px;background:#dfe5f0;color:#16a4d9;display:flex;align-items:center;justify-content:center;font-size:34px;">💬</div>
+            <div style="width:64px;height:64px;border-radius:18px;background:#dfe5f0;color:#333;display:flex;align-items:center;justify-content:center;font-size:36px;">＋</div>
+          </div>
+        </div>
+
+        <div id="list-panel" data-builder-node="ListPanel" data-builder-name="会话列表" style="width:620px;height:100%;background:#f3f4f6;border-radius:32px;padding:22px 16px 12px 16px;box-sizing:border-box;">
+          <div data-builder-node="Tabs" data-builder-name="标签" style="height:68px;border-radius:34px;background:#e8eaee;display:flex;align-items:center;padding:4px;gap:8px;">
+            <div style="height:60px;padding:0 30px;border-radius:30px;background:#1990f5;color:#fff;display:flex;align-items:center;font-size:40px;">全部</div>
+            <div style="font-size:42px;color:#666;">@我</div>
+            <div style="font-size:42px;color:#666;">稍后处理 8</div>
+            <div style="font-size:42px;color:#666;">通知</div>
+          </div>
+
+          <div data-builder-node="List" data-builder-name="会话项" style="margin-top:18px;display:flex;flex-direction:column;gap:8px;">
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#eceff4;font-size:24px;color:#333;">曹苗苗 10:02</div>
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#eceff4;font-size:24px;color:#333;">李付玮 09:02</div>
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#eceff4;font-size:24px;color:#333;">许化翠 08:02</div>
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#eceff4;font-size:24px;color:#333;">周报 08:02</div>
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#d8ddea;font-size:24px;color:#333;">穆红敏 08:02</div>
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#eceff4;font-size:24px;color:#333;">公众号 昨天</div>
+            <div style="height:94px;border-radius:18px;padding:12px 16px;background:#eceff4;font-size:24px;color:#333;">文件传输 昨天</div>
+          </div>
+        </div>
+
+        <div id="chat" data-builder-node="ChatPanel" data-builder-name="聊天窗口" style="flex:1;height:100%;background:#f7f7f8;border-radius:32px;position:relative;padding:24px;box-sizing:border-box;">
+          <div data-builder-node="ChatHeader" data-builder-name="聊天头部" style="height:118px;border-bottom:1px solid #e2e3e7;display:flex;align-items:flex-start;justify-content:space-between;">
+            <div style="display:flex;gap:16px;">
+              <div style="width:72px;height:72px;border-radius:36px;background:#1990f5;color:#fff;display:flex;align-items:center;justify-content:center;font-size:24px;">付玮</div>
+              <div>
+                <div style="font-size:52px;color:#222;font-weight:600;">李付玮 <span style="font-size:42px;color:#999;">👑 开会中</span></div>
+                <div style="font-size:42px;color:#9a9aa0;">360teams管理员</div>
+              </div>
+            </div>
+            <div style="display:flex;gap:40px;font-size:52px;color:#8e9095;align-items:flex-end;padding-right:16px;">
+              <div style="color:#202124;font-weight:600;border-bottom:5px solid #1990f5;padding-bottom:14px;">聊天</div>
+              <div>T5T</div>
+              <div>文件</div>
+            </div>
+          </div>
+
+          <div data-builder-node="Messages" data-builder-name="消息区" style="padding-top:24px;">
+            <div style="font-size:58px;color:#494d55;background:#ececf0;border-radius:28px;padding:18px 26px;display:inline-block;">得再改一版了，修改一次。</div>
+            <div style="margin-top:22px;width:980px;background:#ececf0;border-radius:28px;padding:28px;font-size:54px;line-height:1.45;color:#5b5e66;">烟雨濛濛，不知你是用薄被蒙住双眼，贪恋着甜甜的美梦而不愿露头；还是正神色匆匆，担忧雨势骤大，大步流星地穿梭于人群之中；或或是撑起一把小伞，悠然自得地徜徉在大街小巷，静静看着雨滴从房檐簌簌滴落……</div>
+          </div>
+
+          <div data-builder-node="InputArea" data-builder-name="输入区域" style="position:absolute;left:24px;right:24px;bottom:22px;height:192px;border:2px solid #d8dce5;border-radius:34px;background:#f5f6f8;padding:20px;box-sizing:border-box;">
+            <div style="font-size:52px;color:#b3b5bb;">请输入</div>
+            <div style="position:absolute;left:24px;right:24px;bottom:14px;display:flex;justify-content:space-between;align-items:center;">
+              <div style="font-size:48px;color:#8f9299;">☺ ✂ 📎 📹 📄</div>
+              <div style="font-size:58px;color:#9ca0a9;">➤</div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a static, localized mockup for a meeting/message UI to prototype layout and visuals for the left navigation, conversation list, and chat panel in `meeting_ui.html`.

### Description
- Introduce a new `meeting_ui.html` file containing a full-page Chinese UI mockup with inline styles that implements a sidebar, conversation list, chat header, message area, and input area as a visual prototype.

### Testing
- No automated tests were run for this static HTML addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0288be58308323986b62c092daf15d)